### PR TITLE
Saving child > parent has one

### DIFF
--- a/code/HasOneButtonField.php
+++ b/code/HasOneButtonField.php
@@ -63,8 +63,12 @@ class HasOneButtonRelationList extends DataList{
 	}
 
 	function add($item) {
+		// Set parent > child relationship
 		$this->parent->{$this->name."ID"} = $item->ID;
 		$this->parent->write();
+		
+		// Set child > parent relationship
+		$item->{$this->parent->ClassName."ID"} = $this->parent->ID;
+		$item->write();
 	}
-
 }


### PR DESCRIPTION
The parent child relationship was being set but not the child > parent relationship. 

Example: I could query $this->Child->ID on the parent object but not $this->Partent->ID on the child object.

I am sure there is a more 'ORM' way to do this but this worked for my situation.
