### PR TITLE
Work in progress: Add ability to link/unlink existing records

### DIFF
--- a/src/GridFieldHasOneUnlinkButton.php
+++ b/src/GridFieldHasOneUnlinkButton.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace SilverShop\HasOneField;
+
+use SilverStripe\View\ArrayData;
+use SilverStripe\Control\Controller;
+use SilverStripe\ORM\ValidationException;
+use SilverStripe\Forms\GridField\GridField;
+use SilverStripe\Forms\GridField\GridField_FormAction;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
+use SilverStripe\Forms\GridField\GridField_HTMLProvider;
+use SilverStripe\Forms\GridField\GridField_ActionProvider;
+use SilverStripe\Forms\GridField\GridField_URLHandler;
+
+/**
+ * Class GridFieldHasOneEditButton
+ */
+class GridFieldHasOneUnlinkButton implements GridField_HTMLProvider, GridField_ActionProvider
+{
+    /**
+     * Fragment to write the button to
+     */
+    protected $targetFragment;
+
+    /**
+     * Get fragment to write the button to
+     */ 
+    public function getTargetFragment()
+    {
+        return $this->targetFragment;
+    }
+
+    /**
+     * Set fragment to write the button to
+     *
+     * @return self
+     */ 
+    public function setTargetFragment($targetFragment)
+    {
+        $this->targetFragment = $targetFragment;
+        return $this;
+    }
+
+    /**
+     * The parent record to unlink the current record from
+     * 
+     * @var DataObject
+     */
+    protected $parent;
+
+    /**
+     * Get the parent record to unlink the current record from
+     *
+     * @return DataObject
+     */ 
+    public function getParent()
+    {
+        return $this->parent;
+    }
+
+    /**
+     * Set the parent record to unlink the current record from
+     *
+     * @param DataObject $parent The parent record to unlink the current record from
+     *
+     * @return self
+     */ 
+    public function setParent(DataObject $parent)
+    {
+        $this->parent = $parent;
+        return $this;
+    }
+
+    public function __construct($parent, $targetFragment = "before")
+    {
+        $this->parent = $parent;
+        $this->targetFragment = $targetFragment;
+    }
+
+    /**
+     *
+     * @param GridField $gridField
+     * @return array
+     */
+    public function getActions($gridField)
+    {
+        return ['unlinkrelation'];
+    }
+
+    /**
+     * Manipulate the state to add a new relation
+     *
+     * @param GridField $gridField
+     * @param string $actionName Action identifier, see {@link getActions()}.
+     * @param array $arguments Arguments relevant for this
+     * @param array $data All form data
+     */
+    public function handleAction(GridField $gridField, $actionName, $arguments, $data)
+    {
+        if ($actionName == 'unlinkrelation') {
+            $parent = $this->parent;
+            $record = $gridField->getRecord();
+
+            if (!$record || $record && !$record->exists()) {
+                return;
+            }
+            
+            $item = $gridField->getList()->byID($record->ID);
+    
+            if (!$item) {
+                return;
+            }
+    
+            if (!$item->canEdit()) {
+                throw new ValidationException(
+                    _t(__CLASS__ . '.EditPermissionsFailure', "No permission to unlink record")
+                );
+            }
+    
+            $gridField->getList()->remove($item);
+
+            $response = Controller::curr()->getResponse();
+            $response->setStatusCode(
+                200,
+                _t(__CLASS__ . '.Unlinked', "Unlinked")
+            );
+        }
+    }
+
+    public function getHTMLFragments($gridField)
+    {
+        $record = $gridField->getRecord();
+
+        if ($record->exists()) {
+            $field = new GridField_FormAction(
+                $gridField,
+                'gridfield_unlinkrelation',
+                _t(__CLASS__ . '.Unlink', "Unlink"),
+                'unlinkrelation',
+                'unlinkrelation'
+            );
+            $field->setAttribute('data-icon', 'chain--plus');
+            $field->addExtraClass('btn btn-outline-secondary font-icon-link-broken action_gridfield_unlinkrelation');
+
+            return array(
+                $this->targetFragment => $field->Field()
+            );
+        }
+    }
+}

--- a/src/GridFieldSummaryField.php
+++ b/src/GridFieldSummaryField.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace SilverShop\HasOneField;
+
+use SilverStripe\View\ArrayData;
+use SilverStripe\Forms\TextField;
+use SilverStripe\Control\Controller;
+use SilverStripe\Forms\GridField\GridFieldAddNewButton;
+use SilverStripe\Forms\GridField\GridField_HTMLProvider;
+use SilverStripe\Forms\ReadonlyField;
+
+/**
+ * Class GridFieldSummaryField
+ */
+class GridFieldSummaryField implements GridField_HTMLProvider
+{
+
+    /**
+     * The location of this fragmemt
+     * 
+     * @var string
+     */
+    protected $targetFragment;
+
+    /**
+     * Get the value of targetFragment
+     */ 
+    public function getTargetFragment()
+    {
+        return $this->targetFragment;
+    }
+
+    /**
+     * Set the value of targetFragment
+     *
+     * @param string $targetFragment The target fragment 
+     * 
+     * @return self
+     */ 
+    public function setTargetFragment($targetFragment)
+    {
+        $this->targetFragment = $targetFragment;
+        return $this;
+    }
+
+    /**
+     * @var string
+     */
+    protected $summaryField;
+
+    /**
+     * Get the value of summaryField
+     *
+     * @return string
+     */ 
+    public function getSummaryField()
+    {
+        return $this->summaryField;
+    }
+
+    /**
+     * Set the value of summaryField
+     *
+     * @param string $summaryField The field name
+     *
+     * @return self
+     */ 
+    public function setSummaryField(string $summaryField)
+    {
+        $this->summaryField = $summaryField;
+        return $this;
+    }
+
+    /**
+     * Setup this component
+     *
+     * @param string $targetFragment The location of this fragment
+     * @param string $summaryField   The field on the record to use for the summary 
+     */
+    public function __construct($targetFragment = 'before', $summaryField = "Title")
+    {
+        $this->targetFragment = $targetFragment;
+        $this->summaryField = $summaryField;
+    }
+
+    /**
+     * Generate HTML for the GridField
+     * 
+     * @param GridField $gridField The current GridField
+     * 
+     * @return array
+     */
+    public function getHTMLFragments($gridField)
+    {
+        $record = $gridField->getRecord();
+        $summary = $this->summaryField;
+
+        $field = ReadonlyField::create(
+            'gridfield_hasone_summary',
+            $record->i18n_singular_name()
+        );
+        
+        $field->setValue($record->{$summary});
+
+        return array(
+            $this->targetFragment => $field->Field()
+        );
+    }
+}

--- a/src/GridFieldSummaryField.php
+++ b/src/GridFieldSummaryField.php
@@ -16,6 +16,36 @@ class GridFieldSummaryField implements GridField_HTMLProvider
 {
 
     /**
+     * The name of the relation
+     *
+     * @var string 
+     */
+    protected $name;
+
+    /**
+     * Get the value of name
+     *
+     * @return string
+     */ 
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * Set the value of name
+     *
+     * @param string $name the relation name
+     *
+     * @return self
+     */ 
+    public function setName(string $name)
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    /**
      * The location of this fragmemt
      * 
      * @var string
@@ -74,11 +104,13 @@ class GridFieldSummaryField implements GridField_HTMLProvider
     /**
      * Setup this component
      *
-     * @param string $targetFragment The location of this fragment
+     * @param string $name           The name of the relation
      * @param string $summaryField   The field on the record to use for the summary 
+     * @param string $targetFragment The location of this fragment
      */
-    public function __construct($targetFragment = 'before', $summaryField = "Title")
+    public function __construct($name, $summaryField = "Title", $targetFragment = 'before')
     {
+        $this->name = $name;
         $this->targetFragment = $targetFragment;
         $this->summaryField = $summaryField;
     }
@@ -94,16 +126,17 @@ class GridFieldSummaryField implements GridField_HTMLProvider
     {
         $record = $gridField->getRecord();
         $summary = $this->summaryField;
+        $name = $this->name;
 
         $field = ReadonlyField::create(
             'gridfield_hasone_summary',
-            $record->i18n_singular_name()
+            $name
         );
         
         $field->setValue($record->{$summary});
 
-        return array(
-            $this->targetFragment => $field->Field()
-        );
+        return [
+            $this->targetFragment => $field->FieldHolder()
+        ];
     }
 }

--- a/src/HasOneButtonField.php
+++ b/src/HasOneButtonField.php
@@ -5,6 +5,7 @@ namespace SilverShop\HasOneField;
 use SilverStripe\Forms\GridField\GridField;
 use SilverStripe\Forms\GridField\GridFieldConfig;
 use SilverStripe\Forms\GridField\GridFieldDetailForm;
+use SilverStripe\Forms\GridField\GridFieldAddExistingAutocompleter;
 
 /**
  * Class HasOneButtonField
@@ -20,9 +21,20 @@ class HasOneButtonField extends GridField
         $this->record = $parent->{$name}();
         $this->parent = $parent;
         $config = GridFieldConfig::create()
-                    ->addComponent(new GridFieldDetailForm())
-                    ->addComponent(new GridFieldHasOneEditButton());
+            ->addComponent(new GridFieldSummaryField($name))
+            ->addComponent(new GridFieldDetailForm())
+            ->addComponent(new GridFieldHasOneEditButton())
+            ->addComponent(new GridFieldHasOneUnlinkButton($parent));
+
+        if (!$this->record->exists()) {
+            $config->addComponent(new GridFieldAddExistingAutocompleter());
+        }
+
         $list = new HasOneButtonRelationList($this->record, $name, $parent);
+
+        // Limit the existing list so that autocomplete will find results
+        $list = $list->filter("ID", $this->record->ID);
+
         parent::__construct($name, $title, $list, $config);
     }
 

--- a/src/HasOneButtonRelationList.php
+++ b/src/HasOneButtonRelationList.php
@@ -26,4 +26,10 @@ class HasOneButtonRelationList extends DataList
         $this->parent->{$this->name."ID"} = $item->ID;
         $this->parent->write();
     }
+
+    public function remove($item)
+    {
+        $this->parent->{$this->name."ID"} = 0;
+        $this->parent->write();
+    }
 }


### PR DESCRIPTION
This module works great, but you cannot link existing records (or unlink a record once linked).

This PR lays some of the groundwork, but I am am now kind of stuck...

Basically, the `GridFieldAddExistingAutoCompleter` and the new `GridFieldHasOneUnlinkButton` work, but they do not force the `GridField` to reload (or possibly, the `GridField` is not properly updated on reload).

I was wondering if you guys might have some insight? I am assuming you would like to add this functionality (to me it makes sense to be able to link/unlink as well as just add new)?