### PR TITLE
Fix small bug in PHP versions under 7.1, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,3 @@ In Warehouse.php context:
 ```
 
 You must pass through the parent context ($this), so that the has_one relationship can be set by the `GridFieldDetailForm`.
-
-## Caveats
-
-The field name must match the has_one relationship name.

--- a/src/HasOneButtonField.php
+++ b/src/HasOneButtonField.php
@@ -48,7 +48,7 @@ class HasOneButtonField extends GridField
     /**
      * @param DataObject|null $record
      */
-    public function setRecord($record): void
+    public function setRecord($record)
     {
         $this->record = $record ?: singleton(get_class($this->record));
     }

--- a/src/HasOneButtonField.php
+++ b/src/HasOneButtonField.php
@@ -32,7 +32,7 @@ class HasOneButtonField extends GridField
             ->addComponent(new GridFieldHasOneEditButton())
             ->addComponent(new GridFieldHasOneUnlinkButton($parent));
 
-        $list = new HasOneButtonRelationList($this->record, $relationName, $parent);
+        $list = HasOneButtonRelationList::create($parent, $this->record, $relationName);
 
         parent::__construct($fieldName ?: $relationName, $title, $list, $config);
     }

--- a/src/HasOneButtonRelationList.php
+++ b/src/HasOneButtonRelationList.php
@@ -3,33 +3,52 @@
 namespace SilverShop\HasOneField;
 
 use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\DataObject;
 
 /**
  * Class HasOneButtonRelationList
  */
 class HasOneButtonRelationList extends DataList
 {
+    /**
+     * @var DataObject
+     */
     protected $record;
+
+    /**
+     * @var string
+     */
     protected $name;
+
+    /**
+     * @var DataObject
+     */
     protected $parent;
 
-    public function __construct($record, $name, $parent)
+    /**
+     * HasOneButtonRelationList constructor.
+     * @param DataObject $parent
+     * @param DataObject $record
+     * @param string $name
+     */
+    public function __construct(DataObject $parent, DataObject $record, $name)
     {
         $this->record = $record;
         $this->name = $name;
         $this->parent = $parent;
+
         parent::__construct($record->ClassName);
     }
 
     public function add($item)
     {
-        $this->parent->{$this->name."ID"} = $item->ID;
+        $this->parent->setField("{$this->name}ID", $item->ID);
         $this->parent->write();
     }
 
     public function remove($item)
     {
-        $this->parent->{$this->name."ID"} = 0;
+        $this->parent->setField("{$this->name}ID", 0);
         $this->parent->write();
     }
 }


### PR DESCRIPTION
Hey @wilr,

Just noticed a small bug - I left a return type annotation in, which will cause a ParseError on PHP versions before 7.1

Also:
- updated constructor signature of `HasOneRelationList` to be consistent with `HasOneButtonField`
- updated readme as my earlier PR #15 removes the restriction on field name / relation name having to be the name.