### PR TITLE
Fix polymorphic relations

### DIFF
--- a/src/HasOneButtonField.php
+++ b/src/HasOneButtonField.php
@@ -46,7 +46,7 @@ class HasOneButtonField extends GridField
      */
     public function __construct(DataObject $parent, $relationName, $fieldName = null, $title = null)
     {
-        $this->record = $parent->{$relationName}();
+        $this->setRecord($parent->{$relationName}());
         $this->parent = $parent;
         $this->relation = $relationName;
 

--- a/src/HasOneButtonRelationList.php
+++ b/src/HasOneButtonRelationList.php
@@ -2,13 +2,13 @@
 
 namespace SilverShop\HasOneField;
 
-use SilverStripe\ORM\DataList;
+use SilverStripe\ORM\ArrayList;
 use SilverStripe\ORM\DataObject;
 
 /**
  * Class HasOneButtonRelationList
  */
-class HasOneButtonRelationList extends DataList
+class HasOneButtonRelationList extends ArrayList
 {
     /**
      * @var DataObject
@@ -37,18 +37,22 @@ class HasOneButtonRelationList extends DataList
         $this->relationName = $relationName;
         $this->parent = $parent;
 
-        parent::__construct($record->ClassName);
+        parent::__construct([$record]);
     }
 
     public function add($item)
     {
         $this->parent->setField("{$this->relationName}ID", $item->ID);
         $this->parent->write();
+
+        $this->items = [$item];
     }
 
     public function remove($item)
     {
         $this->parent->setField("{$this->relationName}ID", 0);
         $this->parent->write();
+
+        $this->items = [];
     }
 }

--- a/src/HasOneButtonRelationList.php
+++ b/src/HasOneButtonRelationList.php
@@ -42,7 +42,7 @@ class HasOneButtonRelationList extends ArrayList
 
     public function add($item)
     {
-        $this->parent->setField("{$this->relationName}ID", $item->ID);
+        $this->parent->{$this->relationName} = $item;
         $this->parent->write();
 
         $this->items = [$item];
@@ -50,7 +50,7 @@ class HasOneButtonRelationList extends ArrayList
 
     public function remove($item)
     {
-        $this->parent->setField("{$this->relationName}ID", 0);
+        $this->parent->{$this->relationName} = null;
         $this->parent->write();
 
         $this->items = [];

--- a/src/HasOneButtonRelationList.php
+++ b/src/HasOneButtonRelationList.php
@@ -18,7 +18,7 @@ class HasOneButtonRelationList extends DataList
     /**
      * @var string
      */
-    protected $name;
+    protected $relationName;
 
     /**
      * @var DataObject
@@ -29,12 +29,12 @@ class HasOneButtonRelationList extends DataList
      * HasOneButtonRelationList constructor.
      * @param DataObject $parent
      * @param DataObject $record
-     * @param string $name
+     * @param string $relationName
      */
-    public function __construct(DataObject $parent, DataObject $record, $name)
+    public function __construct(DataObject $parent, DataObject $record, $relationName)
     {
         $this->record = $record;
-        $this->name = $name;
+        $this->relationName = $relationName;
         $this->parent = $parent;
 
         parent::__construct($record->ClassName);
@@ -42,13 +42,13 @@ class HasOneButtonRelationList extends DataList
 
     public function add($item)
     {
-        $this->parent->setField("{$this->name}ID", $item->ID);
+        $this->parent->setField("{$this->relationName}ID", $item->ID);
         $this->parent->write();
     }
 
     public function remove($item)
     {
-        $this->parent->setField("{$this->name}ID", 0);
+        $this->parent->setField("{$this->relationName}ID", 0);
         $this->parent->write();
     }
 }


### PR DESCRIPTION
- Use `$dataObject->{relationName}` for setting relation. Setting `ID` will break polymorphic relations. It will also run any custom setters (e.g. `setRelationName`) defined by the user code, etc.
- Convert `HasOneButtonRelationList` to extend `ArrayList` not `DataList`. This means it won't have to query the database an extra time to refetch the same object.