### PR TITLE
FIX: HasOneButtonField $parent->$relation method call

### DIFF
--- a/src/HasOneButtonField.php
+++ b/src/HasOneButtonField.php
@@ -46,7 +46,8 @@ class HasOneButtonField extends GridField
      */
     public function __construct(DataObject $parent, $relationName, $fieldName = null, $title = null)
     {
-        $this->setRecord($parent->{$relationName}());
+        $record = $parent->{$relationName}();
+        $this->setRecord($record);
         $this->parent = $parent;
         $this->relation = $relationName;
 
@@ -70,7 +71,7 @@ class HasOneButtonField extends GridField
         $this->addExtraClass("d-flex align-items-start");
 
         parent::__construct($fieldName ?: $relationName, $title, $list, $config);
-        $this->setModelClass(($parent->$relationName)->ClassName);
+        $this->setModelClass($record->ClassName);
     }
 
     /**


### PR DESCRIPTION
When not explicitly looking for a method, $parent->$relation has been known to return an array (a gridfield state array). Make sure we use an explicit method call instead.

More details here: https://github.com/silvershop/silverstripe-hasonefield/pull/23