### PR TITLE
Added ability to provide a custom gridfield config.

### DIFF
--- a/src/HasOneButtonField.php
+++ b/src/HasOneButtonField.php
@@ -44,7 +44,7 @@ class HasOneButtonField extends GridField
      * @param string|null $fieldName
      * @param string|null $title
      */
-    public function __construct(DataObject $parent, $relationName, $fieldName = null, $title = null, $customConfig = array())
+    public function __construct(DataObject $parent, $relationName, $fieldName = null, $title = null, GridFieldConfig $customConfig = null)
     {
         $record = $parent->{$relationName}();
         $this->setRecord($record);
@@ -54,21 +54,13 @@ class HasOneButtonField extends GridField
         Requirements::css("silvershop/silverstripe-hasonefield:client/css/hasonefield.css");
         Requirements::javascript("silvershop/silverstripe-hasonefield:client/js/hasonefield.js");
 
-        if (!empty($customConfig)) {
-            $config = GridFieldConfig::create();
-            foreach ($customConfig as $component) {
-                $config->addComponent($component);
-            }
-        }
-        else {
-            $config = GridFieldConfig::create()
-                ->addComponent(new GridFieldHasOneButtonRow())
-                ->addComponent(new GridFieldSummaryField($relationName))
-                ->addComponent(new GridFieldDetailForm())
-                ->addComponent(new GridFieldHasOneUnlinkButton($parent, 'buttons-before-right'))
-                ->addComponent(new GridFieldHasOneEditButton('buttons-before-right'))
-                ->addComponent(new HasOneAddExistingAutoCompleter('buttons-before-right'));
-        }
+        $config = GridFieldConfig::create()
+            ->addComponent(new GridFieldHasOneButtonRow())
+            ->addComponent(new GridFieldSummaryField($relationName))
+            ->addComponent(new GridFieldDetailForm())
+            ->addComponent(new GridFieldHasOneUnlinkButton($parent, 'buttons-before-right'))
+            ->addComponent(new GridFieldHasOneEditButton('buttons-before-right'))
+            ->addComponent(new HasOneAddExistingAutoCompleter('buttons-before-right'));
 
         $list = HasOneButtonRelationList::create($parent, $this->record, $relationName);
 
@@ -78,7 +70,7 @@ class HasOneButtonField extends GridField
         // Get columns to display inline
         $this->addExtraClass("d-flex align-items-start");
 
-        parent::__construct($fieldName ?: $relationName, $title, $list, $config);
+        parent::__construct($fieldName ?: $relationName, $title, $list, ($customConfig) ?: $config);
         $this->setModelClass($record->ClassName);
     }
 
@@ -144,4 +136,3 @@ class HasOneButtonField extends GridField
         return $this;
     }
 }
-

--- a/src/HasOneButtonField.php
+++ b/src/HasOneButtonField.php
@@ -44,7 +44,7 @@ class HasOneButtonField extends GridField
      * @param string|null $fieldName
      * @param string|null $title
      */
-    public function __construct(DataObject $parent, $relationName, $fieldName = null, $title = null)
+    public function __construct(DataObject $parent, $relationName, $fieldName = null, $title = null, $customConfig = array())
     {
         $record = $parent->{$relationName}();
         $this->setRecord($record);
@@ -54,13 +54,21 @@ class HasOneButtonField extends GridField
         Requirements::css("silvershop/silverstripe-hasonefield:client/css/hasonefield.css");
         Requirements::javascript("silvershop/silverstripe-hasonefield:client/js/hasonefield.js");
 
-        $config = GridFieldConfig::create()
-            ->addComponent(new GridFieldHasOneButtonRow())
-            ->addComponent(new GridFieldSummaryField($relationName))
-            ->addComponent(new GridFieldDetailForm())
-            ->addComponent(new GridFieldHasOneUnlinkButton($parent, 'buttons-before-right'))
-            ->addComponent(new GridFieldHasOneEditButton('buttons-before-right'))
-            ->addComponent(new HasOneAddExistingAutoCompleter('buttons-before-right'));
+        if (!empty($customConfig)) {
+            $config = GridFieldConfig::create();
+            foreach ($customConfig as $component) {
+                $config->addComponent($component);
+            }
+        }
+        else {
+            $config = GridFieldConfig::create()
+                ->addComponent(new GridFieldHasOneButtonRow())
+                ->addComponent(new GridFieldSummaryField($relationName))
+                ->addComponent(new GridFieldDetailForm())
+                ->addComponent(new GridFieldHasOneUnlinkButton($parent, 'buttons-before-right'))
+                ->addComponent(new GridFieldHasOneEditButton('buttons-before-right'))
+                ->addComponent(new HasOneAddExistingAutoCompleter('buttons-before-right'));
+        }
 
         $list = HasOneButtonRelationList::create($parent, $this->record, $relationName);
 
@@ -136,3 +144,4 @@ class HasOneButtonField extends GridField
         return $this;
     }
 }
+


### PR DESCRIPTION
Allows config to be customized from the parent forms. I needed the ability to allow the user to select the type of class they wanted to create.

eg.

```
// This helper allows us to define the types of pages we can create.
$classCreator = new GridFieldAddNewMultiClass('buttons-before-right');
$classCreator->setClasses([RelationType1::class, RelationType2::class. RelationType3::class]);

$config = [
  new GridFieldHasOneButtonRow(),
  new GridFieldSummaryField("RelationType"),
  new GridFieldHasOneUnlinkButton($this, 'buttons-before-right'),
  $classCreator
];

$fields->removeByName("RelationTypeID");
$fields->addFieldToTab("Root.Main",
  HasOneButtonField::create($this, "RelationType", null, null, $config)
);
```
Might be of use to other folks.