### PR TITLE
FIX: Dont include jquery or entwine

### DIFF
--- a/src/HasOneButtonField.php
+++ b/src/HasOneButtonField.php
@@ -52,8 +52,6 @@ class HasOneButtonField extends GridField
         $this->relation = $relationName;
 
         Requirements::css("silvershop/silverstripe-hasonefield:client/css/hasonefield.css");
-        Requirements::javascript('silverstripe/admin:thirdparty/jquery/jquery.js');
-        Requirements::javascript('silverstripe/admin:thirdparty/jquery-entwine/dist/jquery.entwine-dist.js');
         Requirements::javascript("silvershop/silverstripe-hasonefield:client/js/hasonefield.js");
 
         $config = GridFieldConfig::create()


### PR DESCRIPTION
Don't overwrite libs bundled into:
/resources/vendor/silverstripe/admin/client/dist/js/vendor.js
see https://github.com/jonom/silverstripe-text-target-length/pull/17
see https://github.com/symbiote/silverstripe-gridfieldextensions/issues/246