### PR TITLE
BUGFIX Silverstripe 5 depreciations in AutoCompleter

### DIFF
--- a/src/HasOneAddExistingAutoCompleter.php
+++ b/src/HasOneAddExistingAutoCompleter.php
@@ -130,7 +130,7 @@ class HasOneAddExistingAutoCompleter extends GridFieldAddExistingAutocompleter
 
         Config::nest();
 
-        SSViewer::config()->update('source_file_comments', false);
+        SSViewer::config()->set('source_file_comments', false);
 
         $viewer = SSViewer::fromString($this->resultsFormat);
 
@@ -147,7 +147,7 @@ class HasOneAddExistingAutoCompleter extends GridFieldAddExistingAutocompleter
         Config::unnest();
 
         return HTTPResponse::create()
-            ->setBody(Convert::array2json($json))
+            ->setBody(json_encode($json))
             ->addHeader('Content-Type', 'text/json');
     }
 }


### PR DESCRIPTION
This fixes 2 Silverstripe 5 depreciations in the `HasOneAddExistingAutoCompleter` class

line 133:
`config()->update` to `config()->set`

line 150:
`->setBody(Convert::array2json($json))` to `->setBody(json_encode($json))`